### PR TITLE
excluding cmake and make files from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,13 @@
 *~
 build*/*
+CMakeCache.txt
+CMakeFiles/*
+Makefile
+cmake_install.cmake
+lib/CMakeFiles/*
+lib/Makefile
+lib/cmake_install.cmake
+version.h
+lib/country_names_xml.cpp
+lib/form_templates_xml.cpp
+lib/messages_xml.cpp


### PR DESCRIPTION
Just a few lines added to .gitignore in order to exclude files created by cmake and make