### PR TITLE
AdminLanguageWidget and CodeEditor Language selection

### DIFF
--- a/docroot/css/ojudge.css
+++ b/docroot/css/ojudge.css
@@ -300,7 +300,9 @@ body {
   text-align:right;
   border-right:1px solid #ccc;
 }
-
+.vertical_scrollable{
+  overflow-y: scroll;
+}
 .oj-admin-category-tree,
 .oj-admin-problem-table,
 .oj-admin-language-table,
@@ -402,6 +404,23 @@ body {
   background:linear-gradient(to right, var(--ojcolor) 0%, var(--ojcolor) 70%, white 100%);
   background-color:var(--ojcolor);
   color:white;
+}
+
+.oj-code-card {
+  border: 1px solid #ccc;
+  background-color: var(--ojcolor);
+  box-shadow: 0 0 5px -1px rgba(0,0,0,0.2);
+  cursor: pointer;
+  text-align: center;
+  mix-blend-mode: hard-light;
+  font-weight: bold;
+  color: rgb(29, 26, 26);
+}
+
+.oj-code-card:hover {
+  background-color: var(--ojcolor);
+  mix-blend-mode: darken;
+  box-shadow: 0 0 5px -1px rgba(0,0,0,0.6);
 }
 
 .oj-editor-toolbar {

--- a/lib/AdminWidget.cpp
+++ b/lib/AdminWidget.cpp
@@ -406,6 +406,7 @@ void AdminWidget::AdminLanguageWidget::showAddEditDialog(const WModelIndex& inde
 	auto name = cpp14::make_unique<WLineEdit>();
 	name->setValidator(nameValidator);
 	name_ = name.get();
+	name_->setFocus();
 
 	auto aceStyle = cpp14::make_unique<WLineEdit>();
 	aceStyle_ = aceStyle.get();
@@ -446,9 +447,9 @@ void AdminWidget::AdminLanguageWidget::showAddEditDialog(const WModelIndex& inde
 
 	auto codeSkeletonProgress = cpp14::make_unique<WProgressBar>();
 	WProgressBar *codeSkeletonProgress_ = codeSkeletonProgress.get();
-	codeSkeleton_->setProgressBar(compileScriptProgress_);
+	codeSkeleton_->setProgressBar(codeSkeletonProgress_);
 
-	auto errorMessage = cpp14::make_unique<WText>("asdf");
+	auto errorMessage = cpp14::make_unique<WText>("");
 	WText *errorMessage_ = errorMessage.get();
 
 	result->bindString("namelabel",WString("Name"));
@@ -492,12 +493,34 @@ void AdminWidget::AdminLanguageWidget::showAddEditDialog(const WModelIndex& inde
 
 void AdminWidget::AdminLanguageWidget::addDialogDone(DialogCode code) {
 	if(code == DialogCode::Accepted) {
-		std::vector<unsigned char> rs = {'a'};
 		std::unordered_map<std::string, Wt::cpp17::any> args;
 		args["name"] = name_->text().toUTF8();
 		args["compilerVersion"] = compilerVersion_->text().toUTF8();
-		args["aceStyle"] = aceStyle_->text().toUTF8();
-		args["runScript"] = rs;
+		if(!aceStyle_->text().empty())
+			args["aceStyle"] = aceStyle_->text().toUTF8();
+		
+		std::ifstream runScriptFile(runScript_->spoolFileName(), std::ios::binary);
+		std::vector<unsigned char> runScriptFileContents(std::istreambuf_iterator<char>{runScriptFile},{});
+		args["runScript"] = runScriptFileContents;
+		
+		if(!codeSkeleton_->empty()){
+			std::ifstream codeSkeletonFile(codeSkeleton_->spoolFileName(), std::ios::binary);
+			std::vector<unsigned char> codeSkeletonFileContents(std::istreambuf_iterator<char>{codeSkeletonFile},{});
+			args["codeSkeleton"] = codeSkeletonFileContents;
+		}
+
+		if(!linkScript_->empty()){
+			std::ifstream linkScriptFile(linkScript_->spoolFileName(), std::ios::binary);
+			std::vector<unsigned char> linkScriptFileContents(std::istreambuf_iterator<char>{linkScriptFile},{});
+			args["linkScript"] = linkScriptFileContents;
+		}
+
+		if(!compileScript_->empty()){
+			std::ifstream compileScriptFile(compileScript_->spoolFileName(), std::ios::binary);
+			std::vector<unsigned char> compileScriptFileContents(std::istreambuf_iterator<char>{compileScriptFile},{});
+			args["compileScript"] = compileScriptFileContents;
+		}
+
 		viewModels_->getLanguageModel()->addLanguage(args);
 	}
 

--- a/lib/AdminWidget.h
+++ b/lib/AdminWidget.h
@@ -127,10 +127,17 @@ Wt::WTableView *tableWidget_;
 std::shared_ptr<Wt::WSortFilterProxyModel> proxyModel_;
 ViewModels *viewModels_;
 Wt::WDialog *addDialog_;
+Wt::WLineEdit *name_;
+Wt::WLineEdit *aceStyle_;
+Wt::WLineEdit *compilerVersion_;
+Wt::WFileUpload *compileScript_;
+Wt::WFileUpload *linkScript_;
+Wt::WFileUpload *runScript_;
+Wt::WFileUpload *codeSkeleton_;
+Wt::WText *errorMessage_;
 
 void showAddEditDialog(const Wt::WModelIndex& index = Wt::WModelIndex());
 void addDialogDone(Wt::DialogCode code);
-
 class AdminActionsDelegate : public Wt::WAbstractItemDelegate {
 public:
 AdminActionsDelegate();

--- a/lib/ProblemWidget.h
+++ b/lib/ProblemWidget.h
@@ -20,6 +20,8 @@
 #include "widgets/OJRatingSetWidget.h"
 #include "datastore/DataStore.h"
 #include "datastore/ProblemStore.h"
+#include "datastore/LanguageStore.h"
+#include "datastore/SubmissionStore.h"
 #include "dbmodel/DBModel.h"
 
 class ViewModels;

--- a/lib/datastore/LanguageStore.cpp
+++ b/lib/datastore/LanguageStore.cpp
@@ -49,26 +49,32 @@ const LanguageData& LanguageStore::getLanguage(long long id) {
 	return languageData_.at(id);
 }
 
-/*
-   void LanguageStore::addLanguage(long long id, std::string title, const WModelIndex& parent) {
 
-        std::lock_guard<std::mutex> guard(addLanguage_mutex);
+void LanguageStore::addLanguage(std::unordered_map<std::string, Wt::cpp17::any> args, const Wt::WModelIndex& parent) {
 
-        dbo::ptr<Problem> problem = dbModel_->addProblem(id,title);
+	std::lock_guard<std::mutex> guard(addLanguage_mutex);
 
-        ProblemData tmpProblemData;
-        tmpProblemData.id = id;
-        tmpProblemData.title = title;
+	dbo::ptr<Language> language = dbModel_->addLanguage(args);
 
-        int row = problemData_.size();
-        problemData_[row] = tmpProblemData;
+	LanguageData tmpLanguageData;
+	tmpLanguageData.id = language.id();
+	tmpLanguageData.name = language->name;
+	tmpLanguageData.runScript = language->runScript;
+	tmpLanguageData.compilerVersion = language->compilerVersion;
 
-        auto server = Wt::WServer::instance();
-        server->postAll([=]{
-                auto app = dynamic_cast<ojudgeApp*>(Wt::WApplication::instance());
-                assert(app != nullptr);
-                app->getViewModels()->getProblemModel()->insertProblem(row,parent);
-                app->triggerUpdate();
-        });
-   }
- */
+	if(args.find("aceStyle") != args.end()){
+		tmpLanguageData.aceStyle = Wt::cpp17::any_cast<std::string>(args["aceStyle"]);
+	}
+
+	int row = languageData_.size();
+	languageData_[row] = tmpLanguageData;
+
+	auto server = Wt::WServer::instance();
+	server->postAll([=]{
+			auto app = dynamic_cast<ojudgeApp*>(Wt::WApplication::instance());
+			assert(app != nullptr);
+			app->getViewModels()->getLanguageModel()->insertLanguage(row, parent);
+			app->triggerUpdate();
+	});
+}
+

--- a/lib/datastore/LanguageStore.h
+++ b/lib/datastore/LanguageStore.h
@@ -13,6 +13,8 @@
 #include <string>
 #include <map>
 #include <Wt/WModelIndex.h>
+#include <unordered_map>
+#include <any>
 
 class DBModel;
 
@@ -33,7 +35,7 @@ public:
 LanguageStore(DBModel *dbModel);
 const std::map<long long,LanguageData>& getLanguages();
 const LanguageData& getLanguage(long long id);
-//void addLanguage(long long id, std::string title, const Wt::WModelIndex& parent);
+void addLanguage(std::unordered_map<std::string, Wt::cpp17::any> args, const Wt::WModelIndex& parent) ;
 
 private:
 DBModel *dbModel_;

--- a/lib/datastore/UserStore.h
+++ b/lib/datastore/UserStore.h
@@ -48,6 +48,7 @@ enum class UserSettingType {
 	EditorIndent,
 	EditorWrap,
 	EditorTheme,
+	EditorStyle,
 	AvatarType,
 	Avatar,
 	Username,

--- a/lib/dbmodel/DBModel.cpp
+++ b/lib/dbmodel/DBModel.cpp
@@ -339,13 +339,9 @@ dbo::ptr<Language> DBModel::addLanguage(std::unordered_map<std::string, cpp17::a
 
 	auto language = std::unique_ptr<Language>(new Language());
 	
-	std::cerr << "A\n" << std::endl;
 	language->name = cpp17::any_cast<std::string>(args["name"]);
-	std::cerr << "A\n" << std::endl;
 	language->compilerVersion = cpp17::any_cast<std::string>(args["compilerVersion"]);
-	std::cerr << "A\n" << std::endl;
 	language->runScript = cpp17::any_cast<std::vector<unsigned char>>(args["runScript"]);
-	std::cerr << "A\n" << std::endl;
 	
 	if(args.find("description") != args.end())
 		language->description = cpp17::any_cast<std::string>(args["description"]);
@@ -358,7 +354,6 @@ dbo::ptr<Language> DBModel::addLanguage(std::unordered_map<std::string, cpp17::a
 	if(args.find("linkScript") != args.end())
 		language->linkScript = cpp17::any_cast<std::vector<unsigned char>>(args["linkScript"]);
 	
-	std::cerr << "A\n" << std::endl;
 	dbo::Transaction t = startTransaction();
 	auto languageRet = session_->add(std::move(language));
 

--- a/lib/dbmodel/DBModel.cpp
+++ b/lib/dbmodel/DBModel.cpp
@@ -329,6 +329,56 @@ dbo::ptr<UserSettings> DBModel::getUserSettings(const Auth::User& user) {
 	return userData->settings;
 }
 
+dbo::ptr<Language> DBModel::addLanguage(std::unordered_map<std::string, cpp17::any> args){
+	
+	bool mandatoryArgsNotNull = true;
+	mandatoryArgsNotNull = mandatoryArgsNotNull && args.find("name") != args.end(); 
+	mandatoryArgsNotNull = mandatoryArgsNotNull && args.find("compilerVersion") != args.end(); 
+	mandatoryArgsNotNull = mandatoryArgsNotNull && args.find("runScript") != args.end(); 
+	//if (!mandatoryArgsNotNull) return ;
+
+	auto language = std::unique_ptr<Language>(new Language());
+	
+	std::cerr << "A\n" << std::endl;
+	language->name = cpp17::any_cast<std::string>(args["name"]);
+	std::cerr << "A\n" << std::endl;
+	language->compilerVersion = cpp17::any_cast<std::string>(args["compilerVersion"]);
+	std::cerr << "A\n" << std::endl;
+	language->runScript = cpp17::any_cast<std::vector<unsigned char>>(args["runScript"]);
+	std::cerr << "A\n" << std::endl;
+	
+	if(args.find("description") != args.end())
+		language->description = cpp17::any_cast<std::string>(args["description"]);
+	if(args.find("codeSkeleton") != args.end())
+		language->codeSkeleton = cpp17::any_cast<std::vector<unsigned char>>(args["codeSkeleton"]);
+	if(args.find("aceStyle") != args.end())
+		language->aceStyle = cpp17::any_cast<std::string>(args["aceStyle"]);
+	if(args.find("compileScript") != args.end())
+		language->compileScript = cpp17::any_cast<std::vector<unsigned char>>(args["compileScript"]);
+	if(args.find("linkScript") != args.end())
+		language->linkScript = cpp17::any_cast<std::vector<unsigned char>>(args["linkScript"]);
+	
+	std::cerr << "A\n" << std::endl;
+	dbo::Transaction t = startTransaction();
+	auto languageRet = session_->add(std::move(language));
+
+	if(args.find("submissions") != args.end())
+	{
+		for (const dbo::ptr<Submission> &submission : std::any_cast<Submissions>(args["submissions"])){
+			languageRet.modify()->submissions.insert(submission);
+		}
+	}
+
+	if(args.find("contests") != args.end())
+	{
+		for (const dbo::ptr<Contest> &contest : std::any_cast<Contests>(args["contests"])){
+			languageRet.modify()->contests.insert(contest);
+		}
+	}
+
+	return languageRet;
+}
+
 Languages DBModel::getLanguages() {
 
 	dbo::Transaction t = startTransaction();

--- a/lib/dbmodel/DBModel.h
+++ b/lib/dbmodel/DBModel.h
@@ -24,6 +24,8 @@
 #include <Wt/WGlobal.h>
 #include <Wt/Auth/Dbo/AuthInfo.h>
 #include <string>
+#include <unordered_map>
+#include <any>
 
 using namespace Wt;
 
@@ -251,6 +253,7 @@ std::optional<int> editor_fontsize;
 std::optional<int> editor_indent;
 std::optional<bool> editor_wrap;
 std::optional<std::string> editor_theme;
+std::optional<std::string> editor_style;
 std::optional<bool> notifications_email_results;
 std::optional<bool> notifications_email_contests;
 std::optional<bool> notifications_email_general;
@@ -648,6 +651,7 @@ void updateSiteSetting(std::string settingName, std::string settingValue);
 dbo::ptr<UserSettings> getUserSettings(const Auth::User& user);
 
 Languages getLanguages();
+dbo::ptr<Language> addLanguage(std::unordered_map<std::string, cpp17::any> args);
 
 private:
 Session* session_;

--- a/lib/ojudgeApp.cpp
+++ b/lib/ojudgeApp.cpp
@@ -386,6 +386,11 @@ void ojudgeApp::showLoginBar() {
 	WAnimation anim(AnimationEffect::SlideInFromTop | AnimationEffect::Fade);
 
 	loginWidget_->animateShow(anim);
+	doJavaScript("setTimeout(() => { \
+		document.getElementById('username_field').control.focus() \
+		}," + std::to_string(anim.duration()) + ");");
+	
+
 }
 
 void ojudgeApp::logout() {

--- a/lib/viewmodels/LanguageModel.cpp
+++ b/lib/viewmodels/LanguageModel.cpp
@@ -13,35 +13,39 @@
 
 using namespace Wt;
 
-LanguageModel::LanguageModel(LanguageStore *languageStore) : WAbstractTableModel(), languageStore_(languageStore) {
-
+LanguageModel::LanguageModel(LanguageStore *languageStore) : WAbstractTableModel(), languageStore_(languageStore)
+{
 }
 
-/*
-   void ProblemModel::addProblem(long long id, std::string title, const WModelIndex& parent) {
-        problemStore_->addProblem(id,title,parent);
-   }
+void LanguageModel::addLanguage(std::unordered_map<std::string, Wt::cpp17::any> args, const WModelIndex &parent)
+{
+	languageStore_->addLanguage(args, parent);
+}
 
-   void ProblemModel::insertProblem(int row, const WModelIndex& parent) {
+void LanguageModel::insertLanguage(int row, const WModelIndex &parent)
+{
 
-        beginInsertRows(parent,row,row);
-        endInsertRows();
+	beginInsertRows(parent, row, row);
+	endInsertRows();
+}
 
-   }
- */
-
-int LanguageModel::columnCount(const WModelIndex& parent) const {
+int LanguageModel::columnCount(const WModelIndex &parent) const
+{
 	return 4;
 }
 
-int LanguageModel::rowCount(const WModelIndex& parent) const {
+int LanguageModel::rowCount(const WModelIndex &parent) const
+{
 	return languageStore_->getLanguages().size();
 }
 
-cpp17::any LanguageModel::data(const WModelIndex& index, ItemDataRole role) const {
+cpp17::any LanguageModel::data(const WModelIndex &index, ItemDataRole role) const
+{
 
-	if(role == ItemDataRole::Display) {
-		switch(index.column()) {
+	if (role == ItemDataRole::Display)
+	{
+		switch (index.column())
+		{
 		case 0:
 			return languageStore_->getLanguage(index.row()).id;
 		case 1:
@@ -51,21 +55,28 @@ cpp17::any LanguageModel::data(const WModelIndex& index, ItemDataRole role) cons
 		case 3:
 			return index.row();
 		}
-	} else if(role == ItemDataRole::StyleClass) {
-		if(index.column()==0) {
+	}
+	else if (role == ItemDataRole::StyleClass)
+	{
+		if (index.column() == 0)
+		{
 			return std::string("oj-admin-language-table");
 		}
-	} else if(role == LanguageRowRole) {
+	}
+	else if (role == LanguageRowRole)
+	{
 		return index.row();
 	}
 
 	return cpp17::any();
-
 }
 
-cpp17::any LanguageModel::headerData(int section, Orientation orientation, ItemDataRole role) const {
-	if(orientation == Orientation::Horizontal && role == ItemDataRole::Display) {
-		switch(section) {
+cpp17::any LanguageModel::headerData(int section, Orientation orientation, ItemDataRole role) const
+{
+	if (orientation == Orientation::Horizontal && role == ItemDataRole::Display)
+	{
+		switch (section)
+		{
 		case 0:
 			return std::string("ID");
 		case 1:

--- a/lib/viewmodels/LanguageModel.h
+++ b/lib/viewmodels/LanguageModel.h
@@ -14,22 +14,22 @@
 
 class LanguageStore;
 
-class LanguageModel : public Wt::WAbstractTableModel {
+class LanguageModel : public Wt::WAbstractTableModel
+{
 public:
+   static constexpr Wt::ItemDataRole LanguageRowRole = Wt::ItemDataRole::User + 3;
 
-static constexpr Wt::ItemDataRole LanguageRowRole = Wt::ItemDataRole::User + 3;
+   LanguageModel(LanguageStore *languageStore);
+   virtual int columnCount(const Wt::WModelIndex &parent = Wt::WModelIndex()) const override;
+   virtual int rowCount(const Wt::WModelIndex &parent = Wt::WModelIndex()) const override;
+   virtual Wt::cpp17::any data(const Wt::WModelIndex &index, Wt::ItemDataRole role = Wt::ItemDataRole::Display) const override;
+   virtual Wt::cpp17::any headerData(int section, Wt::Orientation orientation = Wt::Orientation::Horizontal, Wt::ItemDataRole role = Wt::ItemDataRole::Display) const override;
 
-LanguageModel(LanguageStore *languageStore);
-virtual int columnCount(const Wt::WModelIndex& parent = Wt::WModelIndex()) const override;
-virtual int rowCount(const Wt::WModelIndex& parent = Wt::WModelIndex()) const override;
-virtual Wt::cpp17::any data(const Wt::WModelIndex& index, Wt::ItemDataRole role = Wt::ItemDataRole::Display) const override;
-virtual Wt::cpp17::any headerData(int section, Wt::Orientation orientation = Wt::Orientation::Horizontal, Wt::ItemDataRole role = Wt::ItemDataRole::Display) const override;
-
-/*void addProblem(long long id, std::string title, const Wt::WModelIndex& parent = Wt::WModelIndex());
-   void insertProblem(int row, const Wt::WModelIndex& parent);*/
+   void addLanguage(std::unordered_map<std::string, Wt::cpp17::any> args, const Wt::WModelIndex &parent = Wt::WModelIndex());
+   void insertLanguage(int row, const Wt::WModelIndex &parent);
 
 private:
-LanguageStore *languageStore_;
+   LanguageStore *languageStore_;
 };
 
 constexpr Wt::ItemDataRole LanguageModel::LanguageRowRole;

--- a/lib/widgets/OJCodeEditorWidget.h
+++ b/lib/widgets/OJCodeEditorWidget.h
@@ -19,17 +19,20 @@
 #include <Wt/WComboBox.h>
 #include <Wt/Json/Object.h>
 #include <Wt/Json/Array.h>
+#include <map>
 
 struct OJCodeEditorSettings {
 	int fontsize;
 	int indent;
 	bool wrap;
 	std::string theme;
+	std::string style;
 };
 
 class OJCodeEditorWidget : public Wt::WCompositeWidget {
 public:
 OJCodeEditorWidget();
+OJCodeEditorWidget(std::map<std::string, std::string> languages);
 std::string code();
 void setCode(const std::string& code);
 void loadCodeFromSession(const std::string& key);
@@ -55,6 +58,7 @@ Wt::WContainerWidget *impl_;
 std::string code_;
 void getEditorCode(std::string editorCode);
 void getAceThemes(std::string aceThemes);
+void getAceStyles();
 Wt::WContainerWidget *editorWidget_;
 std::unique_ptr<Wt::WContainerWidget> savedStatusTmp_;
 Wt::WContainerWidget *savedStatus_;
@@ -64,6 +68,7 @@ std::unique_ptr<Wt::WText> cursorColumnValueTmp_;
 Wt::WText *cursorColumnValue_;
 OJCodeEditorProgress *codeLengthProgress_;
 Wt::WComboBox *editorTheme_;
+Wt::WComboBox *editorStyle_;
 void editorFocus();
 void ensureEditor();
 void saveSettings();
@@ -73,10 +78,13 @@ int tabSize_ = 4;
 int fontSize_ = 16;
 bool wordWrap_ = true;
 std::string theme_ = "textmate";
+std::string style_ = "c_cpp";
 Wt::JSignal<std::string> editorCodeSignal_;
 Wt::JSignal<std::string> aceThemesSignal_;
+std::map<std::string,std::string> languages_;
 Wt::Json::Array aceThemes_;
 void themeChanged(int index);
+void styleChanged(int index);
 Wt::Signal<OJCodeEditorSettings&> settingsChanged_;
 };
 

--- a/lib/xml/form_templates.xml
+++ b/lib/xml/form_templates.xml
@@ -244,6 +244,43 @@
       ${categories}
     </div>
   </message>
+  <message id="addLanguage-template">
+      <div class="form-group">
+        <label for="${id:name}">${namelabel}</label>
+        ${name}
+      </div>
+      <div class="form-group">
+        <label for="${id:aceStyle}">${aceStylelabel}</label>
+        ${aceStyle}
+      </div>
+      <div class="form-group">
+        <label for="${id:compilerVersion}">${compilerVersionlabel}</label>
+        ${compilerVersion}
+      </div>
+      <div class="form-group">
+        <label for="${id:compileScript}">${compileScriptlabel}</label>
+        ${compileScript}
+        ${compileScriptProgress}
+      </div>
+      <div class="form-group">
+        <label for="${id:linkScript}">${linkScriptlabel}</label>
+        ${linkScript}
+        ${linkScriptProgress}
+      </div>
+      <div class="form-group">
+        <label for="${id:runScript}">${runScriptlabel}</label>
+        ${runScript}
+        ${runScriptProgress}
+      </div>
+      <div class="form-group">
+        <label for="${id:codeSkeleton}">${codeSkeletonlabel}</label>
+        ${codeSkeleton}
+        ${codeSkeletonProgress}
+      </div>
+      <div>
+          ${errorMessage}
+      </div>
+  </message>
   <message id="editUser-template">
     ${block:settingsField-template id}
     ${block:settingsField-template username}

--- a/lib/xml/form_templates.xml
+++ b/lib/xml/form_templates.xml
@@ -55,8 +55,8 @@
     <div class="password-auth">
          <div class="username-auth">
           ${block:OJ.Auth.field user-name}
+          ${block:OJ.Auth.fieldpassword password}
           ${block:OJ.Auth.fieldremember remember-me}
-	  ${block:OJ.Auth.fieldpassword password}
           <div class="lost-password">${lost-password}</div>
          </div>
     </div>
@@ -75,7 +75,7 @@
     ${<if:{1}>}
     <div class="form-inline">
     <div class="form-group">
-    <label for="${id:{1}}" class="control-label">
+    <label id='username_field' for="${id:{1}}" class="control-label">
       ${tr:OJ.Auth.{1}}
     </label>
     ${{1}}


### PR DESCRIPTION
AdminLanguageWidget implemented, i've used unordered_map<string, any> to pass the arguments through LanguageStore, LanguageModel and DBModel in order to reduce the amount of arguments on addLanguage function.
Delete and Edit are not implemented yet, same as in AdminProblemWidget and AdminCategoryWidget

The CodeEditor size is responsive now and I change the layout a bit, including an example of "draft card"
 
I also changed the login form to set autofocus on username and password next to username, the reason for this is to make it easy to users to fill the form because they can switch between user and password with only one tab.